### PR TITLE
Guard Publishing

### DIFF
--- a/.github/workflows/publish-mam-build.yml
+++ b/.github/workflows/publish-mam-build.yml
@@ -2,7 +2,8 @@ name: Publish the Microsoft Mobile Application Management Build Gradle Plugin to
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    types: [ closed ]
     branches:
       - master
 

--- a/.github/workflows/publish-mam-sdk.yml
+++ b/.github/workflows/publish-mam-sdk.yml
@@ -2,7 +2,8 @@ name: Publish the Microsoft Mobile Application Management SDK to GitHub Packages
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    types: [ closed ]
     branches:
       - master
 


### PR DESCRIPTION
Previously, when we synced the fork with the upstream project, it would trigger the publishing automation. With the changes in this PR, only PR merges will trigger the publishing automation.